### PR TITLE
Update to latest version of dwca-reader

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
 (defproject dwca-reader-clj/dwca-reader-clj "0.8.0-SNAPSHOT" 
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.gbif/dwca-reader "1.9.1-SNAPSHOT"]
+                 [org.gbif/dwca-reader "1.19-SNAPSHOT"]
                  [net.lingala.zip4j/zip4j "1.3.1"]
                  [com.google.guava/guava "12.0"]
                  [clj-http "0.5.7"]]
   :source-paths ["src/clj"]
   :profiles {:dev
              {:resource-paths
-              ["/mnt/hgfs/Dropbox/github/vertnet/dwca-reader-clj/dev"],
+              ["dev"],
               :dependencies [[midje "1.4.0"]]
               :plugins [[lein-swank "1.4.4"]
                         [lein-midje "1.0.8"]

--- a/test/dwca/core_test.clj
+++ b/test/dwca/core_test.clj
@@ -35,7 +35,7 @@
   "Check index-of function."
   (let [dir (.getPath (io/resource "archive-occ"))
         rec (first (get-records dir))]
-    (index-of rec :scientificname) => 159))
+    (index-of rec :scientificname) => 137))
 
 (fact
   "Check opening archive."


### PR DESCRIPTION
Addresses item three of [Gulo#122](https://github.com/VertNet/gulo/issues/122) - "Update gulo to use the reader from GBIF (https://github.com/gbif/dwca-reader/)"
